### PR TITLE
Catch when no audio input was found

### DIFF
--- a/MusicBeam/MusicBeam.pde
+++ b/MusicBeam/MusicBeam.pde
@@ -63,13 +63,8 @@ void setup() {
   surface.setTitle("MusicBeam v"+version);
   PImage titlebaricon = loadImage("icon.png");
   surface.setIcon(titlebaricon);
-
-  Minim minim = new Minim(this);
-  in = minim.getLineIn(Minim.STEREO, 512);
-
-  bdFreq = new BeatDetect(in.bufferSize(), in.sampleRate());
-  bdSound = new BeatDetect();
-
+  
+  initAudioInput();
 
   colorMode(HSB, 360, 100, 100);
 
@@ -343,4 +338,23 @@ private boolean hasEnoughScreenDevices()
   if(gs.length < 2)
     return false;
   return true;
+}
+
+private void initAudioInput()
+{
+  String msg = "No audio input found!\n\n"
+             + "Please check the audio settings on your current operating system.\n"
+             + "There must be at least one audio input activated.";
+  
+  minim = new Minim(this);
+  in = minim.getLineIn(Minim.STEREO, 512);
+  
+  if(in == null)
+  {
+    JOptionPane.showMessageDialog(null, msg);
+    System.exit(1);
+  }
+  
+  bdFreq = new BeatDetect(in.bufferSize(), in.sampleRate());
+  bdSound = new BeatDetect();
 }


### PR DESCRIPTION
This catches the issue when no audio input was found
This might catch the java exception that is thrown on some systems

You can test this when you deactivate every audio input on your operating system

Fix for #28 