### PR TITLE
Division by zero

### DIFF
--- a/MusicBeam/Moonflower_Effect.pde
+++ b/MusicBeam/Moonflower_Effect.pde
@@ -29,7 +29,7 @@ public class Moonflower_Effect extends Effect
     radiusSlider.getCaptionLabel().set("Radius").align(ControlP5.RIGHT, ControlP5.CENTER);
     radiusSlider.setValue(stg.getMinRadius()/5);
 
-    speedSlider = cp5.addSlider("speed"+getName()).setPosition(0, 55).setSize(395, 45).setRange(0.01, 1).setGroup(controlGroup);
+    speedSlider = cp5.addSlider("speed"+getName()).setPosition(0, 55).setSize(395, 45).setRange(0.01, 0.99).setGroup(controlGroup);
     speedSlider.getCaptionLabel().set("speed").align(ControlP5.RIGHT, ControlP5.CENTER);
     speedSlider.setValue(0.5);
 


### PR DESCRIPTION
Speed often gets calculated like this:
`x / 1 - speedValue` which causes a division by zero when speedValue is 1

MaxRange should be 0.99

Fix for #25 